### PR TITLE
DBC-5. Fix query parameter incorrect preparation

### DIFF
--- a/src/main/java/com/github/darrmirr/dbchange/sql/executor/PreparedSql.java
+++ b/src/main/java/com/github/darrmirr/dbchange/sql/executor/PreparedSql.java
@@ -56,7 +56,11 @@ public final class PreparedSql {
                     inSingleQuote = true;
                 } else if (c == '"') {
                     inDoubleQuote = true;
-                } else if (c == ':' && i + 1 < length && Character.isJavaIdentifierStart(query.charAt(i + 1))) {
+                } else if (c == ':'                                               // sql query parameter indicator
+                        && i + 1 < length                                         // make checking next condition safe
+                        && Character.isJavaIdentifierStart(query.charAt(i + 1))   // verify that parameter name is valid one
+                        && (i == 0 || query.charAt(i - 1) != ':')                 // check for postgres sql `::type` cast expression
+                ) {
                     int j = i + 2;
                     while (j < length && Character.isJavaIdentifierPart(query.charAt(j))) {
                         j++;

--- a/src/test/java/com/github/darrmirr/dbchange/sql/executor/PreparedSqlTest.java
+++ b/src/test/java/com/github/darrmirr/dbchange/sql/executor/PreparedSqlTest.java
@@ -59,4 +59,13 @@ class PreparedSqlTest {
 
         assertThat(preparedSql.get(), equalTo(sql));
     }
+
+    @Test
+    void queryPostgresqlCastShort() {
+        String sql = "select '3'::int";
+
+        PreparedSql preparedSql = PreparedSql.of(sql);
+
+        assertThat(preparedSql.get(), equalTo(sql));
+    }
 }


### PR DESCRIPTION
Fix query parameter incorrect preparation if sql query contains postgresql cast expression with double semicolon.